### PR TITLE
[WIP] Performance

### DIFF
--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -154,18 +154,21 @@
         }
         dirtyChunks.forEach(prepareChunk);
 
-        collection.data = [];
-        // this is recreated on load anyway, so we can make metadata smaller
-        collection.isIndex = [];
+        // save collection metadata as separate chunk (but only if changed)
+        if (collection.dirty) {
+          // this is recreated on load anyway, so we can make metadata smaller
+          collection.idIndex = [];
+          collection.data = [];
 
-        // save collection metadata as separate chunk, leave only names in loki
-        // TODO: To reduce IO, we should only save this chunk when it has changed
-        var metadataChunk = JSON.stringify(collection);
-        savedLength += metadataChunk.length;
-        chunksToSave.push({
-          key: collection.name + ".metadata",
-          value: metadataChunk,
-        });
+          var metadataChunk = JSON.stringify(collection);
+          savedLength += metadataChunk.length;
+          chunksToSave.push({
+            key: collection.name + ".metadata",
+            value: metadataChunk,
+          });
+        }
+
+        // leave only names in the loki chunk
         loki.collections[i] = { name: collection.name };
       };
       loki.collections.forEach(prepareCollection);

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -36,7 +36,7 @@
     function IncrementalIndexedDBAdapter(options) {
       this.mode = "incremental";
       this.options = options || {};
-      this.chunkSize = 100;
+      this.chunkSize = 200;
       this.idb = null; // will be lazily loaded on first operation that needs it
     }
 
@@ -143,7 +143,34 @@
 
         // Serialize chunks to save
         var prepareChunk = function (chunkId) {
-          var chunkData = that._getChunk(collection, chunkId);
+          var chunkData = that._getChunk(collection, chunkId).map(x => {
+            if (collection.name === 'comments') {
+              return [x.$loki,
+              x.id,
+              x._status,
+              x._changed,
+              x.author_id,
+              x.body,
+              x.created_at,
+              x.edited_at,
+              x.extra,
+              x.is_deleted,
+              x.is_pinned,
+              x.reactions,
+              x.task_id]
+            } else if (collection.name === 'task_events') {
+              return [x.$loki,
+              x.id,
+              x._status,
+              x._changed,
+              x.author_id,
+              x.created_at,
+              x.change,
+              x.task_id]
+            } else {
+              return x
+            }
+          });
           // we must stringify now, because IDB is asynchronous, and underlying objects are mutable
           var chunkData = JSON.stringify(chunkData);
           savedLength += chunkData.length;
@@ -429,6 +456,7 @@
 
     IncrementalIndexedDBAdapter.prototype._getAllChunks = function(dbname, callback) {
       var that = this;
+      // return callback([])
       if (!this.idb) {
         this._initializeIDB(dbname, callback, function() {
           that._getAllChunks(dbname, callback);
@@ -444,17 +472,185 @@
 
       var tx = this.idb.transaction(['LokiIncrementalData'], "readonly");
 
-      var request = tx.objectStore('LokiIncrementalData').getAll();
-      request.onsuccess = function(e) {
-        that.operationInProgress = false;
-        var chunks = e.target.result;
-        callback(chunks);
-      };
+      // console.time('get keys')
+      // var keysReq = tx.objectStore('LokiIncrementalData').getAllKeys()
+      // // console.log(keysReq.result)
+      // keysReq.onsuccess = e => {
+      //   console.log(e.target.result)
+      //   console.timeEnd('get keys')
+      // }
+      // keysReq.onerror = e => {
+      //   console.error('error with keys')
+      // }
 
-      request.onerror = function(e) {
-        that.operationInProgress = false;
-        callback(e);
-      };
+      // console.time('get contents')
+      // const allChunks = []
+      // var cursor = tx.objectStore('LokiIncrementalData').openCursor()
+      // cursor.onsuccess = e => {
+      //   const cur = e.target.result
+      //   if (cur) {
+      //     // allChunks.push(JSON.parse(cur.value.value))
+      //     const val = JSON.parse(cur.value.value)
+      //     for (var j=0,jl=val.length;j<jl;j++) {
+      //       allChunks.push(val[j])
+      //     }
+      //     cur.continue()
+      //   } else {
+      //     console.log('done!')
+      //     console.timeEnd('get contents')
+      //   }
+      // }
+
+      console.time('get contents')
+      const allChunks = []
+      const store = tx.objectStore('LokiIncrementalData')
+      let count = 0
+      const done = () => {
+        count += 1
+        if (count === 8) {
+          console.timeEnd('get contents')
+          // console.log(allChunks)
+        }
+      }
+      const processChunkyChunk1 = e => {
+        const cur = e.target.result
+        cur.forEach((item, i) => {
+          const val = JSON.parse(item.value)
+          cur[i] = null
+          for (var j=0,jl=val.length;j<jl;j++) {
+            allChunks.push(val[j])
+          }
+        })
+        done()
+      }
+      const processChunkyChunk2 = e => {
+        const cur = e.target.result
+        cur.forEach((item, i) => {
+          const val = JSON.parse(item.value)
+          cur[i] = null
+          if (item.key.includes('comments')) {
+            for (var j=0,jl=val.length;j<jl;j++) {
+              const val1 = val[j]
+              const obj = {
+                $loki: val1[0],
+                id: val1[1],
+                _status: val1[2],
+                _changed: val1[3],
+                author_id: val1[4],
+                body: val1[5],
+                created_at: val1[6],
+                edited_at: val1[7],
+                extra: val1[8],
+                is_deleted: val1[9],
+                is_pinned: val1[10],
+                reactions: val1[11],
+                task_id: val1[12],
+              }
+              allChunks.push(obj)
+            }
+          } else if (item.key.includes('task_events')) {
+            for (var j=0,jl=val.length;j<jl;j++) {
+              const val1 = val[j]
+              const obj = {
+                $loki: val1[0],
+                id: val1[1],
+                _status: val1[2],
+                _changed: val1[3],
+                author_id: val1[4],
+                created_at: val1[5],
+                change: val1[6],
+                task_id: val1[7],
+              }
+              allChunks.push(obj)
+            }
+          } else {
+            for (var j=0,jl=val.length;j<jl;j++) {
+              const val1 = val[j]
+              allChunks.push(val1)
+            }
+          }
+        })
+        done()
+      }
+      const processChunkyChunk = processChunkyChunk2
+      // store.getAll(IDBKeyRange.upperBound('comments.chunk.36', true)).onsuccess = processChunkyChunk
+      // store.getAll(IDBKeyRange.bound('comments.chunk.36', 'task_events.chunk.1', false, true)).onsuccess = processChunkyChunk
+      // store.getAll(IDBKeyRange.bound('task_events.chunk.1', 'task_events.chunk.39', false, true)).onsuccess = processChunkyChunk
+      // store.getAll(IDBKeyRange.lowerBound('task_events.chunk.39', true)).onsuccess = processChunkyChunk
+
+      store.getAll(IDBKeyRange.upperBound('comments.chunk.141', true)).onsuccess = processChunkyChunk
+      store.getAll(IDBKeyRange.bound('comments.chunk.141', 'comments.chunk.36', false, true)).onsuccess = processChunkyChunk
+      store.getAll(IDBKeyRange.bound('comments.chunk.36', 'comments.chunk.81', false, true)).onsuccess = processChunkyChunk
+      store.getAll(IDBKeyRange.bound('comments.chunk.81', 'task_events.chunk.1', false, true)).onsuccess = processChunkyChunk
+      store.getAll(IDBKeyRange.bound('task_events.chunk.1', 'task_events.chunk.144', false, true)).onsuccess = processChunkyChunk
+      store.getAll(IDBKeyRange.bound('task_events.chunk.144', 'task_events.chunk.39', false, true)).onsuccess = processChunkyChunk
+      store.getAll(IDBKeyRange.bound('task_events.chunk.39', 'task_events.chunk.84', false, true)).onsuccess = processChunkyChunk
+      store.getAll(IDBKeyRange.lowerBound('task_events.chunk.84', true)).onsuccess = processChunkyChunk
+
+      // console.time('get contents')
+      // const allChunks = []
+      // var cursor = tx.objectStore('LokiIncrementalData').getAll()
+      // cursor.onsuccess = e => {
+      //   const cur = e.target.result
+      //   cur.forEach((item, i) => {
+      //     const val = JSON.parse(item.value)
+      //     cur[i] = null
+      //     for (var j=0,jl=val.length;j<jl;j++) {
+      //       allChunks.push(val[j])
+      //     }
+      //   })
+      //   console.timeEnd('get contents')
+      //   // console.log(cur)
+      //   // console.log(allChunks)
+      // }
+
+      // const fields=['authorId', 'body', 'createdAt', 'editedAt', 'extra', 'isDeleted', 'isPinned', 'reactions', 'taskId']
+      // const fieldsl = fields.length
+      // console.time('get contents')
+      // const allChunks = []
+      // var cursor = tx.objectStore('LokiIncrementalData').getAll()
+      // cursor.onsuccess = e => {
+      //   const cur = e.target.result
+      //   cur.forEach((item, i) => {
+      //     const val = JSON.parse(item.value)
+      //     cur[i] = null
+      //     for (var j=0,jl=val.length;j<jl;j++) {
+      //       const val1 = val[j]
+      //       // const obj = {}
+      //       // for (var k=0;k<fieldsl;k++) {
+      //       //   obj[fields[k]] = val1[k]
+      //       // }
+      //       const obj = {
+      //         authorId: val1[0],
+      //         body: val1[1],
+      //         createdAt: val1[2],
+      //         editedAt: val1[3],
+      //         extra: val1[4],
+      //         isDeleted: val1[5],
+      //         isPinned: val1[6],
+      //         reactions: val1[7],
+      //         taskId: val1[8],
+      //       }
+      //       allChunks.push(obj)
+      //     }
+      //   })
+      //   console.timeEnd('get contents')
+      //   // console.log(cur)
+      //   // console.log(allChunks)
+      // }
+
+
+      // var request = tx.objectStore('LokiIncrementalData').getAll();
+      // request.onsuccess = function(e) {
+      //   that.operationInProgress = false;
+      //   var chunks = e.target.result;
+      //   callback(chunks);
+      // };
+
+      // request.onerror = function(e) {
+      //   that.operationInProgress = false;
+      //   callback(e);
+      // };
     };
 
     /**

--- a/src/incremental-indexeddb-adapter.js
+++ b/src/incremental-indexeddb-adapter.js
@@ -30,8 +30,10 @@
      * @constructor IncrementalIndexedDBAdapter
      *
      * @param {object=} options Configuration options for the adapter
-     * @param {boolean} options.onversionchange Function to call on `IDBDatabase.onversionchange` event
+     * @param {function} options.onversionchange Function to call on `IDBDatabase.onversionchange` event
      *     (most likely database deleted from another browser tab)
+     * @param {function} options.onFetchStart Function to call once IDB load has begun.
+     *     Use this as an opportunity to execute code concurrently while IDB does work on a separate thread
      */
     function IncrementalIndexedDBAdapter(options) {
       this.mode = "incremental";
@@ -455,6 +457,10 @@
         that.operationInProgress = false;
         callback(e);
       };
+
+      if (this.options.onFetchStart) {
+        this.options.onFetchStart();
+      }
     };
 
     /**

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -534,6 +534,10 @@
         return b.indexOf(a) !== -1;
       },
 
+      $inSet: function(a, b) {
+        return b.has(a);
+      },
+
       $nin: function (a, b) {
         return b.indexOf(a) === -1;
       },
@@ -3549,6 +3553,12 @@
 
         searchByIndex = true;
         index = this.collection.binaryIndices[property];
+      }
+
+      if (!searchByIndex && operator === '$in' && Array.isArray(value)
+        && typeof window !== undefined && typeof window.Set !== 'undefined') {
+        value = new Set(value)
+        operator = '$inSet'
       }
 
       // the comparison function

--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -1128,7 +1128,7 @@
       options = options || {};
 
       // currently inverting and letting loadJSONObject do most of the work
-      databaseCopy.loadJSONObject(this, { retainDirtyFlags: true });
+      databaseCopy.loadJSONObject(this, { retainDirtyFlags: true, skipUniqueIndicies: true });
 
       // since our JSON serializeReplacer is not invoked for reference database adapters, this will let us mimic
       if (options.hasOwnProperty("removeNonSerializable") && options.removeNonSerializable === true) {
@@ -1706,6 +1706,7 @@
      * @param {object} dbObject - a serialized loki database string
      * @param {object=} options - apply or override collection level settings
      * @param {bool} options.retainDirtyFlags - whether collection dirty flags will be preserved
+     * @param {bool} options.skipUniqueIndicies - skip regenerating unique indicies
      * @memberof Loki
      */
     Loki.prototype.loadJSONObject = function (dbObject, options) {
@@ -1810,8 +1811,11 @@
         copyColl.uniqueNames = [];
         if (coll.hasOwnProperty("uniqueNames")) {
           copyColl.uniqueNames = coll.uniqueNames;
-          for (j = 0; j < copyColl.uniqueNames.length; j++) {
-            copyColl.ensureUniqueIndex(copyColl.uniqueNames[j]);
+
+          if (!options.skipUniqueIndicies) {
+            for (j = 0; j < copyColl.uniqueNames.length; j++) {
+              copyColl.ensureUniqueIndex(copyColl.uniqueNames[j]);
+            }
           }
         }
 


### PR DESCRIPTION
Performance improvements to IncrementalIndexedDB:

- skip regenerating unique indices on save (since they're regenerated on load anyway) - this cuts save time in half (120ms to 60ms in my app)
- fix typo that caused idIndex (which is regenerated on load) to be saved. On my [Nozbe Teams](https://nozbe.com/teams) account this cut full metadata save from 3.2MB to 2.5MB
- only save metadata chunks for dirty collections. On the same example app, this cut most DB saves from 2.5MB to as little as 2KB (if a few very heavy collections are not dirtied)
- add a hook to "on IndexedDB started fetching" event, which can be used to speed up an app by taking advantage of concurrency (IDB is partially multi-threaded)

And for all of LokiJS:

- opportunistically convert `$in: Array` queries into `$inSet: Set` queries if indexed search is not available - this changes `O(n*m)` search into `O(n * log m)` search which improved speed of a few of queries in Nozbe Teams by 4-10x. 